### PR TITLE
Event doubling fixes, preventing delete and others

### DIFF
--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -22,6 +22,7 @@ import ida_idaapi
 import ida_idp
 import ida_kernwin
 import ida_nalt
+import ida_netnode
 import ida_pro
 import ida_segment
 import ida_struct
@@ -527,15 +528,15 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
 
     def make_data(self, ea, flags, tid, size):
         self._plugin.logger.debug("make_data(ea = %x, flags = %x, tid = %x, size = %x)" % (ea, flags, tid, size))
-        self._send_packet(evt.MakeDataEvent(ea, flags, size, ida_struct.get_struc_name(tid) if tid != ida_idaapi.BADADDR else ''))
+        self._send_packet(evt.MakeDataEvent(ea, flags, size, ida_struct.get_struc_name(tid) if tid != ida_netnode.BADNODE else ''))
         return 0
 
     def renamed(self, ea, new_name, local_name):
-        old_name = ""
-        if ida_struct.is_member_id(ea) or ida_struct.get_struc_name(ea) or ida_enum.get_enum_name(ea):
+        self._plugin.logger.debug("renamed(ea = %x, new_name = %s, local_name = %d)" % (ea, new_name, local_name))
+        if ida_struct.is_member_id(ea) or ida_struct.get_struc(ea) or ida_enum.get_enum_name(ea):
             # old_name = ida_struct.get_struc_name(ea)
-            return 0 #drop hook for avoid  dublicate 'StrucRenamedEvent', 'EnumRenamedEvent' and 'StrucMemberRenamedEvent'
-        self._send_packet(evt.RenamedEvent(ea, new_name, old_name, local_name))
+            return 0 #drop hook for avoid  duplicate 'StrucRenamedEvent', 'EnumRenamedEvent' and 'StrucMemberRenamedEvent'
+        self._send_packet(evt.RenamedEvent(ea, new_name, local_name))
         return 0
 
     def byte_patched(self, ea, old_value):

--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -78,7 +78,7 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
         # self._plugin.logger.trace(self._plugin.core.local_type_map)
         for i in range(1, ida_typeinf.get_ordinal_qty(ida_typeinf.get_idati())):
             t = ImportLocalType(i)
-            if t and t.name and ida_struct.get_struc_id(t.name) == ida_idaapi.BADADDR:
+            if t and t.name and ida_struct.get_struc_id(t.name) == ida_idaapi.BADADDR and ida_enum.get_enum(t.name) == ida_idaapi.BADADDR:
                 if i in self._plugin.core.local_type_map:
                     t_old = self._plugin.core.local_type_map[i]
                     if t_old and not t.isEqual(t_old):
@@ -167,11 +167,12 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
         # return 0
 
     def ti_changed(self, ea, type, fname):
+        self._plugin.logger.debug("ti_changed(ea = 0x%X, type = %s, fname = %s)"%(ea, type, fname))
         name = ""
         if ida_struct.is_member_id(ea):
             name = ida_struct.get_struc_name(ea)
         type = ida_typeinf.idc_get_type_raw(ea)
-        self._send_packet(evt.TiChangedEvent(ea, (ParseTypeString(type[0]), type[1]), name))
+        self._send_packet(evt.TiChangedEvent(ea, (ParseTypeString(type[0]) if type else [], type[1] if type else None), name))
         return 0
 
     def op_ti_changed(self, ea, n, type, fnames):
@@ -341,7 +342,7 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                     )
                 )
             elif flag & ida_bytes.stru_flag():
-                extra["id"] = mt.tid
+                extra["struc_name"] = ida_struct.get_struc_name(mt.tid)
                 if flag & ida_bytes.strlit_flag():
                     extra["strtype"] = mt.strtype
                 self._send_packet(
@@ -396,7 +397,7 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                     )
                 )
             elif flag & ida_bytes.stru_flag():
-                extra["id"] = mt.tid
+                extra["struc_name"] = ida_struct.get_struc_name(mt.tid)
                 if flag & ida_bytes.strlit_flag():
                     extra["strtype"] = mt.strtype
                 self._send_packet(
@@ -525,15 +526,15 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
     #     return 0
 
     def make_data(self, ea, flags, tid, size):
-        # TODO: tid --> struct name
         self._plugin.logger.debug("make_data(ea = %x, flags = %x, tid = %x, size = %x)" % (ea, flags, tid, size))
-        self._send_packet(evt.MakeDataEvent(ea, flags, size, tid))
+        self._send_packet(evt.MakeDataEvent(ea, flags, size, ida_struct.get_struc_name(tid) if tid != ida_idaapi.BADADDR else ''))
         return 0
 
     def renamed(self, ea, new_name, local_name):
         old_name = ""
-        if ida_struct.is_member_id(ea):
-            old_name = ida_struct.get_struc_name(ea)
+        if ida_struct.is_member_id(ea) or ida_struct.get_struc_name(ea) or ida_enum.get_enum_name(ea):
+            # old_name = ida_struct.get_struc_name(ea)
+            return 0 #drop hook for avoid  dublicate 'StrucRenamedEvent', 'EnumRenamedEvent' and 'StrucMemberRenamedEvent'
         self._send_packet(evt.RenamedEvent(ea, new_name, old_name, local_name))
         return 0
 

--- a/idarling/interface/dialogs.py
+++ b/idarling/interface/dialogs.py
@@ -248,11 +248,15 @@ class OpenDialog(QDialog):
         d.add_callback(partial(self._group_deleted, group))
         d.add_errback(self._plugin.logger.exception)
 
-    def _group_deleted(self, group, _):
-        for e in self._groups:
-            if e.name == group.name:
-                self._groups.remove(e)
-        self._refresh_groups()
+    def _group_deleted(self, group, reply):
+        if reply.deleted:
+            for e in self._groups:
+                if e.name == group.name:
+                    self._groups.remove(e)
+            self._refresh_groups()
+        else:
+            QMessageBox.about(self, "IDArling Error", "Unable to delete.\n"
+                                                      "Likely more than one client connected to target?")
 
     ##### PROJECTS #####
 
@@ -310,12 +314,16 @@ class OpenDialog(QDialog):
         d.add_callback(partial(self._project_deleted, project))
         d.add_errback(self._plugin.logger.exception)
 
-    def _project_deleted(self, project, _):
-        for e in self._projects:
-            if e.name == project.name:
-                self._projects.remove(e)
-        self._refresh_projects()
-        self._databases_table.clearContents()
+    def _project_deleted(self, project, reply):
+        if reply.deleted:
+            for e in self._projects:
+                if e.name == project.name:
+                    self._projects.remove(e)
+            self._refresh_projects()
+            self._databases_table.clearContents()
+        else:
+            QMessageBox.about(self, "IDArling Error", "Unable to delete.\n"
+                                                      "Likely more than one client connected to target?")
 
     def _rename_project_button_clicked(self, _):
         current_project = self._projects_table.selectedItems()[0].data(Qt.UserRole).name
@@ -389,11 +397,15 @@ class OpenDialog(QDialog):
         d.add_callback(partial(self._database_deleted, database))
         d.add_errback(self._plugin.logger.exception)
 
-    def _database_deleted(self, database, _):
-        for e in self._databases:
-            if e.name == database.name:
-                self._databases.remove(e)
-        self._refresh_databases()
+    def _database_deleted(self, database, reply):
+        if reply.deleted:
+            for e in self._databases:
+                if e.name == database.name:
+                    self._databases.remove(e)
+            self._refresh_databases()
+        else:
+            QMessageBox.about(self, "IDArling Error", "Unable to delete.\n"
+                                                      "Likely more than one client connected to target?")
 
     def _database_double_clicked(self):
         project_type = self._projects_table.selectedItems()[0].data(Qt.UserRole).type

--- a/idarling/shared/commands.py
+++ b/idarling/shared/commands.py
@@ -114,8 +114,10 @@ class DeleteGroup(ParentCommand):
             super(DeleteGroup.Query, self).__init__()
             self.group_name = group_name
 
-    class Reply(IReply, Command):
-        pass
+    class Reply(IReply, DefaultCommand):
+        def __init__(self, query, deleted):
+            super(DeleteGroup.Reply, self).__init__(query)
+            self.deleted = deleted
 
 class CreateProject(ParentCommand):
     __command__ = "create_project"
@@ -143,8 +145,10 @@ class DeleteProject(ParentCommand):
             self.group_name = group_name
             self.project_name = project_name
 
-    class Reply(IReply, Command):
-        pass
+    class Reply(IReply, DefaultCommand):
+        def __init__(self, query, deleted):
+            super(DeleteProject.Reply, self).__init__(query)
+            self.deleted = deleted
 
 
 class CreateDatabase(ParentCommand):
@@ -174,8 +178,10 @@ class DeleteDatabase(ParentCommand):
             self.project_name = project_name
             self.database_name = database_name
 
-    class Reply(IReply, Command):
-        pass
+    class Reply(IReply, DefaultCommand):
+        def __init__(self, query, deleted):
+            super(DeleteDatabase.Reply, self).__init__(query)
+            self.deleted = deleted
 
 class UpdateFile(ParentCommand):
     __command__ = "update_file"


### PR DESCRIPTION
1) Added lock for delete group\project\database with connecting clients.
2) Fixed https://github.com/fidgetingbits/IDArling/issues/56 (deleting typeinfo case)
3) Some fixes in hooks and events.
4) Adding code for avoid event doubling in rename enum\struct\struct member cases.
5) Several ID -> name fixes.