### PR TITLE
fixed the wrong patch for migration.

### DIFF
--- a/idarling/shared/server.py
+++ b/idarling/shared/server.py
@@ -530,12 +530,12 @@ class Server(ServerSocket):
         """
         return {
             "level": logging.INFO,
-            "migration": 0,
+            "migration": -1,
         }
 
     def migrate(self):
         migrationId = self.config["migration"]
-        while migrationId:
+        while migrationId >= 0:
             migrationId += 1
             method_name = "do%d" % migrationId
             try:


### PR DESCRIPTION
Sorry my fix #69  is bad because the migrate method(`Migrate().do1()`) need variable `migrationId` to be 0. 
``` python
migrationId += 1
method_name = "do%d" % migrationId
try:
    method = getattr(Migrate, method_name)
except AttributeError:
    break
method(self)
```
And my fix #69  will cause the migration never executed. 
I change the default `migration` value into `-1`  and check it in the while loop. when first setup the server, the migration will be skipped. if the `migration` value is `0` and migration method `Migrate().do1()` will be executed normally.  