### PR TITLE
Gracefully handle server connection failure

### DIFF
--- a/idarling/network/network.py
+++ b/idarling/network/network.py
@@ -110,8 +110,10 @@ class Network(Module):
         # Connect the socket
         sock.settimeout(0)  # No timeout
         sock.setblocking(0)  # No blocking
-        ret = sock.connect_ex((host, port))
-        if ret != 0 and ret != errno.EINPROGRESS and ret != errno.EWOULDBLOCK:
+        try:
+            sock.connect((host, port))
+        except OSError as e:
+            self._plugin._logger.exception(e)
             self._client.disconnect()
 
     def disconnect(self):

--- a/idarling/plugin.py
+++ b/idarling/plugin.py
@@ -155,12 +155,16 @@ class Plugin(ida_idaapi.plugin_t):
         self._logger.info("Initialized properly")
         keep = ida_idaapi.PLUGIN_KEEP
 
+        self._auto_connect()
+
+        return keep
+
+    def _auto_connect(self):
         for server in self._config["servers"]:
             if "auto_connect" in server and server["auto_connect"]:
-                self.logger.info("Attempting to auto-connect to %s:%d" %
-                        (server["host"], server["port"]))
+                self.logger.info("Attempting to auto-connect to {}:{}".format(
+                                 server["host"], server["port"]))
                 self._network.connect(server)
-        return keep
 
     def _print_banner(self):
         """Print the banner that you see in the console."""


### PR DESCRIPTION
This PR addresses the following scenario:
Suppose you configure auto-connection to an IDArling server with an invalid domain name (perhaps one which is normally valid).
This would cause the `connect_ex` in IDArling's `init` to throw an exception, causing IDArling to terminate.
(To use IDArling once again, the user will have to manually edit the configuration file.)

This PR allows the desired behavior, which is to let the user attempt to reconnect or to try another server.