### PR TITLE
Support enum struct members

### DIFF
--- a/idarling/core/events.py
+++ b/idarling/core/events.py
@@ -588,7 +588,35 @@ class StrucCmtChangedEvent(Event):
             ida_struct.set_struc_cmt(sptr.id, cmt, self.repeatable_cmt)
 
 
-class StrucMemberCreatedEvent(Event):
+class StrucMemberEvent(Event):
+    """
+    Base class inherited by all "struc_member_*" events
+    """
+    @staticmethod
+    def _get_sptr(struct_name):
+        struc_id = ida_struct.get_struc_id(struct_name)
+        return ida_struct.get_struc(struc_id)
+
+    @staticmethod
+    def _get_member_type(type_flag, extra):
+        mt = ida_nalt.opinfo_t()
+        if ida_bytes.is_struct(type_flag):
+            mt.tid = ida_struct.get_struc_id(extra['struc_name'])
+        if type_flag & ida_bytes.off_flag():
+            mt.ri = ida_nalt.refinfo_t()
+            mt.ri.init(
+                extra['flags'],
+                extra['base'],
+                extra['target'],
+                extra['tdelta'],
+            )
+        if ida_bytes.is_strlit(type_flag):
+            mt.strtype = extra['strtype']
+
+        return mt
+
+
+class StrucMemberCreatedEvent(StrucMemberEvent):
     __event__ = "struc_member_created"
 
     def __init__(self, sname, fieldname, offset, flag, nbytes, extra):
@@ -601,21 +629,8 @@ class StrucMemberCreatedEvent(Event):
         self.extra = extra
 
     def __call__(self):
-        mt = ida_nalt.opinfo_t()
-        if ida_bytes.is_struct(self.flag):
-            mt.tid = ida_struct.get_struc_id(self.extra["struc_name"])
-        if ida_bytes.is_off0(self.flag) or ida_bytes.is_off1(self.flag):
-            mt.ri = ida_nalt.refinfo_t()
-            mt.ri.init(
-                self.extra["flags"],
-                self.extra["base"],
-                self.extra["target"],
-                self.extra["tdelta"],
-            )
-        if ida_bytes.is_strlit(self.flag):
-            mt.strtype = self.extra["strtype"]
-        struc = ida_struct.get_struc_id(self.sname)
-        sptr = ida_struct.get_struc(struc)
+        sptr = self._get_sptr(self.sname)
+        mt = self._get_member_type(self.flag, self.extra)
         ida_struct.add_struc_member(
             sptr,
             self.fieldname,
@@ -626,7 +641,7 @@ class StrucMemberCreatedEvent(Event):
         )
 
 
-class StrucMemberChangedEvent(Event):
+class StrucMemberChangedEvent(StrucMemberEvent):
     __event__ = "struc_member_changed"
 
     def __init__(self, sname, soff, eoff, flag, extra):
@@ -638,27 +653,14 @@ class StrucMemberChangedEvent(Event):
         self.extra = extra
 
     def __call__(self):
-        mt = ida_nalt.opinfo_t()
-        if ida_bytes.is_struct(self.flag):
-            mt.tid = ida_struct.get_struc_id(self.extra["struc_name"])
-        if ida_bytes.is_off0(self.flag) or ida_bytes.is_off1(self.flag):
-            mt.ri = ida_nalt.refinfo_t()
-            mt.ri.init(
-                self.extra["flags"],
-                self.extra["base"],
-                self.extra["target"],
-                self.extra["tdelta"],
-            )
-        if ida_bytes.is_strlit(self.flag):
-            mt.strtype = self.extra["strtype"]
-        struc = ida_struct.get_struc_id(self.sname)
-        sptr = ida_struct.get_struc(struc)
+        sptr = self._get_sptr(self.sname)
+        mt = self._get_member_type(self.flag, self.extra)
         ida_struct.set_member_type(
             sptr, self.soff, self.flag, mt, self.eoff - self.soff
         )
 
 
-class StrucMemberDeletedEvent(Event):
+class StrucMemberDeletedEvent(StrucMemberEvent):
     __event__ = "struc_member_deleted"
 
     def __init__(self, sname, offset):
@@ -667,12 +669,11 @@ class StrucMemberDeletedEvent(Event):
         self.offset = offset
 
     def __call__(self):
-        struc = ida_struct.get_struc_id(self.sname)
-        sptr = ida_struct.get_struc(struc)
+        sptr = self._get_sptr(self.sname)
         ida_struct.del_struc_member(sptr, self.offset)
 
 
-class StrucMemberRenamedEvent(Event):
+class StrucMemberRenamedEvent(StrucMemberEvent):
     __event__ = "struc_member_renamed"
 
     def __init__(self, sname, offset, newname):
@@ -682,8 +683,7 @@ class StrucMemberRenamedEvent(Event):
         self.newname = newname
 
     def __call__(self):
-        struc = ida_struct.get_struc_id(self.sname)
-        sptr = ida_struct.get_struc(struc)
+        sptr = self._get_sptr(self.sname)
         ida_struct.set_member_name(
             sptr, self.offset, self.newname
         )

--- a/idarling/core/events.py
+++ b/idarling/core/events.py
@@ -612,7 +612,8 @@ class StrucMemberEvent(Event):
             )
         if type_flag & ida_bytes.enum_flag():
             mt.ec.serial = extra['serial']
-            mt.ec.tid = extra['tid']
+            # Backwards compatibility: Past versions didn't store the tid
+            mt.ec.tid = extra.get('tid', 0)
         if ida_bytes.is_strlit(type_flag):
             mt.strtype = extra['strtype']
 

--- a/idarling/core/events.py
+++ b/idarling/core/events.py
@@ -610,6 +610,9 @@ class StrucMemberEvent(Event):
                 extra['target'],
                 extra['tdelta'],
             )
+        if type_flag & ida_bytes.enum_flag():
+            mt.ec.serial = extra['serial']
+            mt.ec.tid = extra['tid']
         if ida_bytes.is_strlit(type_flag):
             mt.strtype = extra['strtype']
 

--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -334,9 +334,9 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                         sname, fieldname, offset, flag, nbytes, extra
                     )
                 )
-            # Is it really possible to create an enum?
             elif flag & ida_bytes.enum_flag():
                 extra["serial"] = mt.ec.serial
+                extra["tid"] = mt.ec.tid
                 self._send_packet(
                     evt.StrucMemberCreatedEvent(
                         sname, fieldname, offset, flag, nbytes, extra
@@ -392,6 +392,7 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                 )
             elif flag & ida_bytes.enum_flag():
                 extra["serial"] = mt.ec.serial
+                extra["tid"] = mt.ec.tid
                 self._send_packet(
                     evt.StrucMemberChangedEvent(
                         sname, soff, mptr.eoff, flag, extra


### PR DESCRIPTION
Up until this PR, adding enum struct members (or setting a member's type to enum) was not fully supported by IDArling, potentially resulting in the following _ida.dll_ error:

> struct->til conversion failed:
> could not retrieve type of %s

which happened because the parameters IDArling passed to `add_struc_member`/`set_member_type` only indicated that the member is an enum, without specifying its type.

<details>
  <summary>Expand to see how to reproduce this error without IDArling</summary>

```python
struc_id = ida_struct.get_struc_id('some_empty_struct')  # Create this struct beforehand
sptr = ida_struct.get_struc(struc_id)
mt = ida_nalt.opinfo_t()
ida_struct.add_struc_member(sptr, 'my_enum', 0, 0x28800400, mt, 4)
```
</details>

To fix this bug, the field `mt.ec.tid` must be initialized with the enum's type ID before passing `mt` to `add_struc_member`. (A step which was skipped, for some reason.)

Note:
IDArling databases created before this PR will still get the "struct->til" errors.
To amend the old databases, you have to find the proper _tid_ by running `ida_enum.get_enum(my_enum_name)`, and add it to all of the relevant `struc_member_created` and `struc_member_changed` events.
To do so, you have two hacky options:

1. Using some SQLite browser, open `idarling/files/database.db` and add the `extra["tid"]` field manually.
2. Instead, you may temporarily edit your IDArling client's code to initialize `mt.ec.tid` in `_get_member_type(...)` with the correct _tid_. Then, save the IDB to the server and eliminate your workaround code.