### PR TITLE
Fix changing type of union members

### DIFF
--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -375,7 +375,6 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
         extra = {}
 
         sname = ida_struct.get_struc_name(sptr.id)
-        soff = 0 if mptr.unimem() else mptr.soff
         flag = mptr.flag
         mt = ida_nalt.opinfo_t()
         is_not_data = ida_struct.retrieve_member_info(mt, mptr)
@@ -387,14 +386,14 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                 extra["flags"] = mt.ri.flags
                 self._send_packet(
                     evt.StrucMemberChangedEvent(
-                        sname, soff, mptr.eoff, flag, extra
+                        sname, mptr.soff, mptr.eoff, flag, extra
                     )
                 )
             elif flag & ida_bytes.enum_flag():
                 extra["serial"] = mt.ec.serial
                 self._send_packet(
                     evt.StrucMemberChangedEvent(
-                        sname, soff, mptr.eoff, flag, extra
+                        sname, mptr.soff, mptr.eoff, flag, extra
                     )
                 )
             elif flag & ida_bytes.stru_flag():
@@ -403,13 +402,13 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
                     extra["strtype"] = mt.strtype
                 self._send_packet(
                     evt.StrucMemberChangedEvent(
-                        sname, soff, mptr.eoff, flag, extra
+                        sname, mptr.soff, mptr.eoff, flag, extra
                     )
                 )
         else:
             self._send_packet(
                 evt.StrucMemberChangedEvent(
-                    sname, soff, mptr.eoff, flag, extra
+                    sname, mptr.soff, mptr.eoff, flag, extra
                 )
             )
         return 0


### PR DESCRIPTION
### Overview

This PR fixes the call to `ida_struct.set_member_type(...)` in the case where the "struct" is actually a union.

I've come across this bug while investigating the cause of the following _ida.dll_ error (which, at least in my case, was caused indirectly by this bug):

> struct->til conversion failed:
> failed to calculate alignments for %s

### The bug

IDA's API is slightly confusing:

- To add a union member, you call `add_struc_member` with an offset equal to 0.
- To set the type of a union member, you call `set_member_type` with an offset equal to the member's index.

The problem is that IDArling passes an offset of 0 in both cases, always setting the type of the first union member.

### Note regarding IDArling databases created before this PR

See #75.