### PR TITLE
Remove excess LeaveSession packets

### DIFF
--- a/idarling/shared/server.py
+++ b/idarling/shared/server.py
@@ -330,10 +330,6 @@ class ServerClient(ClientSocket):
         packet.silent = False
         self.parent().forward_users(self, packet)
 
-        # Inform ourselves that the other users leaved
-        for user in self.parent().get_users(self):
-            self.send_packet(LeaveSession(user.name))
-
         self._project = None
         self._binary = None
         self._snapshot = None


### PR DESCRIPTION
When a user leaves the session, the `_users` dictionary gets cleared using two methods:

1. By calling `self._users.clear()` in the client.
2. Using `LeaveSession` packets sent to it by the server; one packet for every user.

Because `_users` is empty when `LeaveSession`'s handler tries to pop from it, a _KeyError_ exception will be thrown for each user.

This PR gets rid of these exceptions by not sending the mentioned packets.