### PR TITLE
make float->int conversion explicit

### DIFF
--- a/idarling/interface/widget.py
+++ b/idarling/interface/widget.py
@@ -392,7 +392,7 @@ class StatusWidget(QWidget):
         """Called when the widget is being painted."""
         # Adjust the buffer size according to the pixel ratio
         dpr = self.devicePixelRatioF()
-        buffer = QPixmap(self.width() * dpr, self.height() * dpr)
+        buffer = QPixmap(int(self.width() * dpr), int(self.height() * dpr))
         buffer.setDevicePixelRatio(dpr)
         buffer.fill(Qt.transparent)
 


### PR DESCRIPTION
This used to be a warning but now it's a hard error (not sure exactly when it changed, maybe python 3.9).