### PR TITLE
[Bugfix] Pass flags used for segment deletion

### DIFF
--- a/idarling/core/events.py
+++ b/idarling/core/events.py
@@ -757,13 +757,17 @@ class SegmAddedEvent(Event):
 class SegmDeletedEvent(Event):
     __event__ = "segm_deleted_event"
 
-    def __init__(self, ea):
+    def __init__(self, ea, flags):
         super(SegmDeletedEvent, self).__init__()
         self.ea = ea
+        self.flags = flags
 
     def __call__(self):
+        if not hasattr(self, 'flags'):
+            # segm_deleted events created prior to IDA 7.7 lack flags
+            self.flags = 0
         ida_segment.del_segm(
-            self.ea, ida_segment.SEGMOD_KEEP | ida_segment.SEGMOD_SILENT
+            self.ea, self.flags | ida_segment.SEGMOD_SILENT
         )
 
 

--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -444,9 +444,9 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
         )
         return 0
 
-    # This hook lack of disable addresses option
-    def segm_deleted(self, start_ea, end_ea):
-        self._send_packet(evt.SegmDeletedEvent(start_ea))
+    # The flags argument was added in IDA 7.7
+    def segm_deleted(self, start_ea, end_ea, flags=0):
+        self._send_packet(evt.SegmDeletedEvent(start_ea, flags))
         return 0
 
     def segm_start_changed(self, s, oldstart):


### PR DESCRIPTION
### Example scenario triggered by this bug
Suppose you're opening an IDB using IDArling. After IDArling applies its events, the IDB explodes from 10MB to 14GB (for example), making it completely unusable.
To the average user, there's no obvious fix apart from starting over, potentially losing precious RE work.

### Root cause

IDA offers two ways of deleting segments – one which deletes the segment's addresses from the IDB, and one which doesn't.
If the user creates a large non-sparse segment, the .id1 file will explode (as it stores various flags for each EA). So far, this is expected behavior.

The problem is that until IDA 7.7, the `segm_deleted` event only received the start & end EA as parameters, and not the flags used for the deletion.
So, prior to this PR, IDArling had no optimal choice to make – it could either delete the segment with `SEGMOD_KEEP`, which would have left the IDB bloated, or it could delete it with `SEGMOD_KILL`, potentially destroying precious user information.

### Solution

Now that IDA passes the flags used for deletion to `segm_deleted`, all that's left for IDArling is to use these flags.

Note that IDArling databases with `segm_deleted` events created before this PR (or using IDA < 7.7) will require a manual fix.