### PR TITLE
Fix SSL connections

### DIFF
--- a/idarling/shared/sockets.py
+++ b/idarling/shared/sockets.py
@@ -149,21 +149,11 @@ class ClientSocket(QObject):
 
         # Check if the connection was successful
         ret = self._socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
-        if ret != 0 and ret != errno.EINPROGRESS and ret != errno.EWOULDBLOCK:
-            self.disconnect(socket.error(ret, os.strerror(ret)))
+        if ret != 0:
+            if ret != errno.EINPROGRESS and ret != errno.EWOULDBLOCK:
+                self.disconnect(socket.error(ret, os.strerror(ret)))
             return False
         else:
-            # Do SSL handshake if needed
-            if isinstance(self._socket, ssl.SSLSocket):
-                try:
-                    self._socket.do_handshake()
-                except socket.error as e:
-                    if not isinstance(
-                        e, ssl.SSLWantReadError
-                    ) and not isinstance(e, ssl.SSLWantReadError):
-                        self.disconnect(e)
-                    return False
-
             self._connected = True
             self._logger.info("Connected")
             return True


### PR DESCRIPTION
Wrapped sockets apparently don't work properly on non-blocking sockets when using `connect()` instead of `connect_ex()` - there's a `NoneType` exception because the `_sslobj` of the socket is `None`.

I tested the issue mentioned in #72 with non-existing domains, and it's still behaving properly with the change proposed here.

I also removed the manual handshake code that was added in 2018. There was no indication on why it is needed and I didn't have any trouble on Python 3.8.