### PR TITLE
Fix easy_install.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Install the IDArling client into the IDA plugins folder.
 line into the console:
 
 ```
-import urllib2; exec(urllib2.urlopen('https://raw.githubusercontent.com/fidgetingbits/IDArling/master/easy_install.py')).read()
+import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/fidgetingbits/IDArling/main/easy_install.py').read().decode())
 ```
 
 ### Integrated server

--- a/easy_install.py
+++ b/easy_install.py
@@ -20,7 +20,7 @@ import ida_loader
 
 # Allow the user to override the download URL
 if "URL" not in locals():
-    URL = "https://github.com/fidgetingbits/IDArling/archive/IDArling-main.zip"
+    URL = "https://github.com/fidgetingbits/IDArling/archive/main.zip"
 
 print("[*] Installing IDArling...")
 # Install into the user directory on all platforms

--- a/easy_install.py
+++ b/easy_install.py
@@ -12,7 +12,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import os
 import shutil
-import urllib2
+import urllib.request
 import zipfile
 
 import ida_diskio
@@ -20,7 +20,7 @@ import ida_loader
 
 # Allow the user to override the download URL
 if "URL" not in locals():
-    URL = "https://github.com/IDArlingTeam/IDArling/archive/master.zip"
+    URL = "https://github.com/fidgetingbits/IDArling/archive/IDArling-main.zip"
 
 print("[*] Installing IDArling...")
 # Install into the user directory on all platforms
@@ -29,15 +29,15 @@ plug_dir = os.path.join(user_dir, "plugins")
 if not os.path.exists(plug_dir):
     os.makedirs(plug_dir, 493)  # 0755
 
-print("[*] Downloading master.zip archive...")
-archive_path = os.path.join(plug_dir, "master.zip")
+print("[*] Downloading IDArling-main.zip archive...")
+archive_path = os.path.join(plug_dir, "IDArling-main.zip")
 if os.path.exists(archive_path):
     os.remove(archive_path)
 with open(archive_path, "wb") as f:
-    f.write(urllib2.urlopen(URL).read())
+    f.write(urllib.request.urlopen(URL).read())
 
-print("[*] Unzipping master.zip archive...")
-archive_dir = os.path.join(plug_dir, "IDArling-master")
+print("[*] Unzipping IDArling-main.zip archive...")
+archive_dir = os.path.join(plug_dir, "IDArling-main")
 if os.path.exists(archive_dir):
     shutil.rmtree(archive_dir)
 with zipfile.ZipFile(archive_path, "r") as zip:
@@ -57,7 +57,7 @@ if os.path.exists(dst_dir):
     shutil.rmtree(dst_dir)
 shutil.move(src_dir, dst_dir)
 
-print("[*] Removing master.zip archive...")
+print("[*] Removing IDArling-main.zip archive...")
 if os.path.exists(archive_path):
     os.remove(archive_path)
 if os.path.exists(archive_dir):


### PR DESCRIPTION
# Error
`ModuleNotFoundError: No module named 'urllib2'`
# Changes
- urllib2 → urllib.request
- IDArlingTeam → fidgetingbits
- master → IDArling-main
# Testing
```
Python>import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/laqieer/IDArling/patch-1/easy_install.py').read().decode())
[*] Installing IDArling...
[*] Downloading IDArling-main.zip archive...
[*] Unzipping IDArling-main.zip archive...
[*] Moving the IDArling files...
[*] Removing IDArling-main.zip archive...
[*] Loading IDArling into IDA Pro...
[idarling][INFO] ---------------------------------------------------------------------------
[idarling][INFO] IDArling v0.0.3 - (c) The IDArling Team
[idarling][INFO] ---------------------------------------------------------------------------
[idarling][INFO] Initialized properly
[*] IDArling installed successfully!
```